### PR TITLE
Widen support for branch names

### DIFF
--- a/src/BumpInto.php
+++ b/src/BumpInto.php
@@ -84,7 +84,7 @@ final class BumpInto implements PluginInterface, EventSubscriberInterface
                 continue;
             }
 
-            if (preg_match('~^dev-[\w-]+@dev$~', $version) === 1) {
+            if (preg_match('~^dev-.+@dev$~', $version) === 1) {
                 continue;
             }
 

--- a/test/BumpIntoTest.php
+++ b/test/BumpIntoTest.php
@@ -119,11 +119,11 @@ final class BumpIntoTest extends TestCase
             'expected' => ['malukenho/zend-framework' => 'dev-master#4e4cd83e1bc67fef9efca32f30648011d6d319cb'],
         ];
 
-        yield 'dev-hackfix-composite-key-serialization@dev' => [
+        yield 'dev-hackfix-composite-key-serialization-2.7@dev' => [
             'package' => 'malukenho/zend-framework',
-            'required_version' => 'dev-hackfix-composite-key-serialization@dev',
-            'installed_version' => 'dev-hackfix-composite-key-serialization',
-            'expected' => ['malukenho/zend-framework' => 'dev-hackfix-composite-key-serialization@dev'],
+            'required_version' => 'dev-hackfix-composite-key-serialization-2.7@dev',
+            'installed_version' => 'dev-hackfix-composite-key-serialization-2.7',
+            'expected' => ['malukenho/zend-framework' => 'dev-hackfix-composite-key-serialization-2.7@dev'],
         ];
 
         yield 'dev-hackfix-composite-key-serialization as 1.1.1' => [


### PR DESCRIPTION
In https://github.com/malukenho/mcbumpface/pull/21 I for some reason did not realise the branch name can be kind of complex. I widened support for it here. The regex to match branch name [is complicated](https://stackoverflow.com/a/12093994/519333) but IMO there's no need to replicate it here as git handles it for us, there won't exist a branch with invalid name pushed. So we can just loosen the regex a bit.