### PR TITLE
Fix no dev install

### DIFF
--- a/src/BumpInto.php
+++ b/src/BumpInto.php
@@ -18,6 +18,7 @@ use Composer\Script\ScriptEvents;
 use Generator;
 use function array_key_exists;
 use function array_merge;
+use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
 use function is_numeric;
@@ -34,7 +35,14 @@ final class BumpInto implements PluginInterface, EventSubscriberInterface
 {
     public static function versions(Event $composerEvent) : void
     {
-        $io               = $composerEvent->getIO();
+        $io = $composerEvent->getIO();
+
+        if (! file_exists(__DIR__)) {
+            $io->write('<info>malukenho/mcbumpface:</info> Package not found (probably scheduled for removal); package bumping skipped.');
+
+            return;
+        }
+
         $composer         = $composerEvent->getComposer();
         $locker           = $composer->getLocker();
         $rootPackage      = $composer->getPackage();


### PR DESCRIPTION
I'm still struggling to put this to my `master` :D I guess this is the last issue to be solved. Currently I discovered it when running in CI.

```
composer install
composer install --no-dev --classmap-authoritative --no-progress --no-interaction
```

This installs and uninstalls the extension, however after uninstall the hook is still present. Needs to be skipped.

<details>
  <summary>More details</summary>

   ```  
composer install --no-dev --classmap-authoritative --no-progress --no-interaction
Loading composer repositories with package information
Installing dependencies from lock file
Package operations: 0 installs, 0 updates, 61 removals
  - Removing malukenho/mcbumpface (1.1.1)
Generating optimized autoload files
PHP Fatal error:  Uncaught Error: Class 'Malukenho\McBumpface\ComposerOptions' not found in /work/vendor/malukenho/mcbumpface/src/BumpInto.php:54
Stack trace:
#0 [internal function]: Malukenho\McBumpface\BumpInto::versions(Object(Composer\Script\Event))
#1 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(176): call_user_func(Array, Object(Composer\Script\Event))
#2 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(96): Composer\EventDispatcher\EventDispatcher->doDispatch(Object(Composer\Script\Event))
#3 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/src/Composer/Installer.php(324): Composer\EventDispatcher\EventDispatcher->dispatchScript('post-install-cm...', false)
#4 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/src/Composer/Command/InstallCommand.php(122): Composer\Installer->run()
#5 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/vendor/symfony/console/Command/Command.php(245):  in /work/vendor/malukenho/mcbumpface/src/BumpInto.php on line 54

Fatal error: Uncaught Error: Class 'Malukenho\McBumpface\ComposerOptions' not found in /work/vendor/malukenho/mcbumpface/src/BumpInto.php:54
Stack trace:
#0 [internal function]: Malukenho\McBumpface\BumpInto::versions(Object(Composer\Script\Event))
#1 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(176): call_user_func(Array, Object(Composer\Script\Event))
#2 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(96): Composer\EventDispatcher\EventDispatcher->doDispatch(Object(Composer\Script\Event))
#3 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/src/Composer/Installer.php(324): Composer\EventDispatcher\EventDispatcher->dispatchScript('post-install-cm...', false)
#4 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/src/Composer/Command/InstallCommand.php(122): Composer\Installer->run()
#5 phar:///usr/local/Cellar/composer/1.9.3/bin/composer/vendor/symfony/console/Command/Command.php(245):  in /work/endor/malukenho/mcbumpface/src/BumpInto.php on line 54
```
</details>