### PR TITLE
Restore support for php 7.2

### DIFF
--- a/src/ComposerOptions.php
+++ b/src/ComposerOptions.php
@@ -13,8 +13,10 @@ final class ComposerOptions
 
     /**
      * With this parameter, you can configure your project to either keep or drop the version `v` prefix from versions.
+     *
+     * @var bool
      */
-    private bool $stripVersionPrefixes;
+    private $stripVersionPrefixes;
 
     private function __construct(bool $stripVersionPrefixes)
     {


### PR DESCRIPTION
You added a type for property. Typed properties are available since php 7.4, but in your composer.json min version is 7.2. So without this fix your package doesn't work in projects on php 7.2, 7.3