### PR TITLE
Add option to keep version constraint prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The configuration can be added like this:
 {
     "extra": {
         "mc-bumpface": {
-            "stripVersionPrefixes": false
+            "stripVersionPrefixes": false,
+            "keepVersionConstraintPrefix": false
         }
     }
 }
@@ -59,7 +60,14 @@ The configuration can be added like this:
 The following configurations are available:
 
 - [stripVersionPrefixes](#configuration-stripVersionPrefixes)
+- [keepVersionConstraintPrefix](#configuration-keepVersionConstraintPrefix)
 
 ###### stripVersionPrefixes (default: false)
 <a name="configuration-stripVersionPrefixes"></a> 
 By setting this parameter to `true`, `mcbumpface` will strip the `v` prefix from versions (in case they are tagged like this).  
+
+###### keepVersionConstraintPrefix (default: false)
+<a name="configuration-keepVersionConstraintPrefix"></a>
+By setting this parameter to `true`, `mcbumpface` will NOT replace the version constraint prefix.
+
+Having a required version `~2.0` and installed `2.0.20` will replace the version constraint to `^2.0.20`.

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,16 @@
         "ext-zip": "*",
         "composer/composer": "^1.9.3 || ^2.0.2",
         "doctrine/coding-standard": "^9.0.0",
-        "infection/infection": "^0.26.4",
-        "staabm/annotate-pull-request-from-checkstyle": "^1.4.0",
-        "phpunit/phpunit": "^9.4.4"
+        "infection/infection": "^0.26.13",
+        "staabm/annotate-pull-request-from-checkstyle": "^1.8.3",
+        "phpunit/phpunit": "^9.5.21"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "infection/extension-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/src/BumpInto.php
+++ b/src/BumpInto.php
@@ -86,6 +86,8 @@ final class BumpInto implements PluginInterface, EventSubscriberInterface
         ComposerOptions $options
     ): void {
         foreach ($requiredVersions as $package => $version) {
+            $constraintPrefix = '^';
+
             if (! array_key_exists($package, $lockVersions)) {
                 continue;
             }
@@ -99,8 +101,8 @@ final class BumpInto implements PluginInterface, EventSubscriberInterface
                 continue;
             }
 
-            if (strpos($version, '~') === 0) {
-                continue;
+            if (strpos($version, '~') === 0 && $options->shouldKeepVersionConstraintPrefix()) {
+                $constraintPrefix = '~';
             }
 
             if (strpos($version, ' as ') !== false) {
@@ -137,7 +139,7 @@ final class BumpInto implements PluginInterface, EventSubscriberInterface
                 continue;
             }
 
-            $manipulator->addLink($configKey, $package, '^' . $lockVersion, false);
+            $manipulator->addLink($configKey, $package, $constraintPrefix . $lockVersion, false);
 
             $IO->write(sprintf(
                 '<info>malukenho/mcbumpface</info> is updating <info>%s</info>%s package from version (<info>%s</info>) to (<info>%s</info>)',

--- a/src/ComposerOptions.php
+++ b/src/ComposerOptions.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Malukenho\McBumpface;
@@ -20,16 +21,33 @@ final class ComposerOptions
      */
     private $stripVersionPrefixes;
 
-    private function __construct(bool $stripVersionPrefixes)
+    /**
+     * With this parameter, you can configurate if the version constraint in your composer.json will be kept or
+     * to be replaced with `^`
+     *
+     * E.g.: `~2.1` will be replaced with `^2.1`
+     * Setting this option to true will keep `~2.1`
+     *
+     * phpcs:disable SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+     *
+     * @var bool
+     */
+    private $keepVersionConstraintPrefix;
+
+    private function __construct(bool $stripVersionPrefixes, bool $keepVersionConstraintPrefix)
     {
-        $this->stripVersionPrefixes = $stripVersionPrefixes;
+        $this->stripVersionPrefixes        = $stripVersionPrefixes;
+        $this->keepVersionConstraintPrefix = $keepVersionConstraintPrefix;
     }
 
     public static function fromRootPackage(RootPackageInterface $package): self
     {
         $extra = $package->getExtra()[self::EXTRA_IDENTIFIER] ?? [];
 
-        return new self($extra['stripVersionPrefixes'] ?? false);
+        return new self(
+            $extra['stripVersionPrefixes'] ?? false,
+            $extra['keepVersionConstraintPrefix'] ?? false
+        );
     }
 
     public function manipulateVersionIfNeeded(string $version): string
@@ -39,5 +57,10 @@ final class ComposerOptions
         }
 
         return (string) preg_replace('/^v(?<version>.*)/', '\1', $version);
+    }
+
+    public function shouldKeepVersionConstraintPrefix(): bool
+    {
+        return $this->keepVersionConstraintPrefix;
     }
 }

--- a/test/BumpIntoTest.php
+++ b/test/BumpIntoTest.php
@@ -180,14 +180,15 @@ final class BumpIntoTest extends TestCase
             'package' => 'malukenho/zend-framework',
             'required_version' => '~2.0.20',
             'installed_version' => '2.0.30',
-            'expected' => ['malukenho/zend-framework' => '~2.0.20'],
+            'expected' => ['malukenho/zend-framework' => '~2.0.30'],
+            'options' => ['keepVersionConstraintPrefix' => true],
         ];
 
         yield '~1.2' => [
             'package' => 'malukenho/zend-framework',
             'required_version' => '~1.2',
             'installed_version' => '1.2.3',
-            'expected' => ['malukenho/zend-framework' => '~1.2'],
+            'expected' => ['malukenho/zend-framework' => '^1.2.3'],
         ];
 
         yield '^1.3.0, <1.4.0' => [
@@ -203,6 +204,14 @@ final class BumpIntoTest extends TestCase
             'installed_version' => 'v1.0.1',
             'expected' => ['malukenho/docheader' => '^1.0.1'],
             'options' => ['stripVersionPrefixes' => true],
+        ];
+
+        yield 'constraint prefix ~ should be replaced when disabled' => [
+            'package' => 'malukenho/docheader',
+            'required_version' => '~2.0',
+            'installed_version' => '2.0.30',
+            'expected' => ['malukenho/docheader' => '^2.0.30'],
+            'options' => ['keepVersionConstraintPrefix' => false],
         ];
     }
 


### PR DESCRIPTION
This will add a new option to be configured which can support updating other version constraints other than `^`.
Should resolve #79 