### PR TITLE
feat: include implicit patch version when 0

### DIFF
--- a/test/BumpIntoTest.php
+++ b/test/BumpIntoTest.php
@@ -85,6 +85,13 @@ final class BumpIntoTest extends TestCase
             'expected' => ['malukenho/docheader' => '^1.0.0'],
         ];
 
+        yield '^2.1.0 - include implicit `.0` patch version when only major+minor are installed' => [
+            'package' => 'bentools/iterable-functions',
+            'required_version' => '^2.1.0',
+            'installed_version' => '2.1',
+            'expected' => ['bentools/iterable-functions' => '^2.1.0'],
+        ];
+
         yield 'version with leading "v" char' => [
             'package' => 'malukenho/docheader',
             'required_version' => '^1.0',


### PR DESCRIPTION
What do you think about this case?

Lockfile includes `2.1` but I'd prefer to have `^2.1.0` in my composer.json rather than `^2.1` as former is more explicit.