### PR TITLE
Use $constraintPrefix for display message

### DIFF
--- a/src/BumpInto.php
+++ b/src/BumpInto.php
@@ -146,7 +146,7 @@ final class BumpInto implements PluginInterface, EventSubscriberInterface
                 $package,
                 $configKey === 'require-dev' ? ' dev' : '',
                 $version,
-                '^' . $lockVersion
+                $constraintPrefix . $lockVersion
             ));
         }
     }


### PR DESCRIPTION
When keepVersionConstraintPrefix: true, behaviour is correct but displayed message is wrong (and misleading). For rector/rector:~0.17.13, it maintains constraint prefix, but
says: malukenho/mcbumpface is updating rector/rector package from version (~0.17.13) to (^0.17.13)